### PR TITLE
add qnap support

### DIFF
--- a/upsnutwrapper/upsnutwrapper.sh
+++ b/upsnutwrapper/upsnutwrapper.sh
@@ -265,6 +265,8 @@ elif [ "${COMMAND:0:$VAR_NAME_INDEX}" = "GET VAR $UPSNAME " ]; then	  #requestin
 		elif [ "${COMMAND:$VAR_NAME_INDEX}" = "ups.test.result" ]; then
 			gettestresult #get only test result data
 			echo -en "VAR $UPSNAME ups.test.result \"$UPS_SELFTEST\"\n"
+		else
+			log "failed to process variable"
 		fi
 
 elif [ "$COMMAND" = "LIST VAR $UPSNAME" ]; then			#requesting all values


### PR DESCRIPTION
My QNAP nas (TS-653D) was not supported with the given code.

As far as I could find online, it needs the name of the ups to be "qnapups".
With some logging I also found out that it needs the "ups.test.result" variable, so I introduced it.

In the end I got it to work with my small adaptions.
![image](https://user-images.githubusercontent.com/6935251/206592892-77d033a8-a189-4255-a1de-ba8bd9a50a01.png)


Thank you @gitmachtl for the great starting point.